### PR TITLE
Use pipe in solution for lm fit

### DIFF
--- a/_episodes_rmd/03-twoLvlFactor.Rmd
+++ b/_episodes_rmd/03-twoLvlFactor.Rmd
@@ -116,7 +116,8 @@ summ(TotChol_SmokeNow_lm, confint = TRUE, digits = 3)
 > > ## Solution
 > > 
 > > ```{r}
-> > BPSysAve_PhysActive_lm <- lm(formula = BPSysAve ~ PhysActive, data = dat)
+> > BPSysAve_PhysActive_lm <- dat %>% 
+> >   lm(formula = BPSysAve ~ PhysActive)
 > > 
 > > summ(BPSysAve_PhysActive_lm, confint = TRUE, digits = 3)
 > > ```


### PR DESCRIPTION
At the moment, on line 119, we are fitting the lm by providing the `data = dat` argument.  However in all other examples/solutions, we have used the pipe operator. Whilst obviously this isn't "wrong", I think it makes sense to standardise this. 

My understanding is just the Rmd file needs to be edited, and GH actions will do the rest. Please let me know if I've misunderstood the process used to build and serve the site! 